### PR TITLE
change argument order of implode (#131)

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -1449,7 +1449,7 @@ class Credis_Client {
      */
     private static function _prepare_command($args)
     {
-        return sprintf('*%d%s%s%s', count($args), CRLF, implode(array_map(array('self', '_map'), $args), CRLF), CRLF);
+        return sprintf('*%d%s%s%s', count($args), CRLF, implode(CRLF, array_map(array('self', '_map'), $args)), CRLF);
     }
 
     private static function _map($arg)


### PR DESCRIPTION
to follow the documented order,
reverse order is deprecated from php 7.4 on